### PR TITLE
Bump default GKE version to 1.31

### DIFF
--- a/infra-library.sh
+++ b/infra-library.sh
@@ -21,7 +21,7 @@ source "$(dirname "${BASH_SOURCE[0]:-$0}")/library.sh"
 
 # Default Kubernetes version to use for GKE, if not overridden with
 # the `--cluster-version` parameter.
-readonly GKE_DEFAULT_CLUSTER_VERSION="1.28"
+readonly GKE_DEFAULT_CLUSTER_VERSION="1.31"
 
 # Dumps the k8s api server metrics. Spins up a proxy, waits a little bit and
 # dumps the metrics to ${ARTIFACTS}/k8s.metrics.txt


### PR DESCRIPTION
### **User description**
**Notes for Reviewers**

This PR fixes #




**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


___

### **PR Type**
Enhancement


___

### **Description**
- Updated the default GKE Kubernetes version to 1.31.

- Ensures compatibility with the latest Kubernetes features.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>infra-library.sh</strong><dd><code>Bump default GKE Kubernetes version to 1.31</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infra-library.sh

<li>Updated the <code>GKE_DEFAULT_CLUSTER_VERSION</code> from 1.28 to 1.31.<br> <li> Ensures the script uses the latest Kubernetes version by default.


</details>


  </td>
  <td><a href="https://github.com/khulnasoft/hack/pull/1/files#diff-8b84ef7f9ef2ec700e516990040d807401f6ddf00654155a277f4e3fcc26627e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>